### PR TITLE
Bump amqp-client from 4.12.0 to 5.14.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ Initial release.
 ### Dependency Updates
 
 * Up jmeter-core version to 5.4.3.
-* Up amqp-client version to 4.12.0.
+* Up amqp-client version to 5.14.2.
 * Up commons-lang3 version to 3.12.0.
 
 [unreleased]: https://github.com/aliesbelik/jmeter-amqp-plugin/compare/v0.1.0...HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+### Dependency Updates
+
+* Up amqp-client version to 5.14.2.
+
 ## [0.1.0] - 2022-01-15
 
 Initial release.
@@ -49,7 +53,7 @@ Initial release.
 ### Dependency Updates
 
 * Up jmeter-core version to 5.4.3.
-* Up amqp-client version to 5.14.2.
+* Up amqp-client version to 4.12.0.
 * Up commons-lang3 version to 3.12.0.
 
 [unreleased]: https://github.com/aliesbelik/jmeter-amqp-plugin/compare/v0.1.0...HEAD

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ or any [AMQP](http://www.amqp.org/) message broker.
 ## Requirements
 
 - Requires JDK 8+.
-- Compatible with versions up to **4.12.0** of [com.rabbitmq:amqp-client](https://github.com/rabbitmq/rabbitmq-java-client).
+- Compatible with versions up to **5.14.2** of [com.rabbitmq:amqp-client](https://github.com/rabbitmq/rabbitmq-java-client).
 
 ## Installation
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
     <!-- dependency versions -->
     <jmeter.version>5.4.3</jmeter.version>
-    <amqp.client.version>4.12.0</amqp.client.version>
+    <amqp.client.version>5.14.2</amqp.client.version>
     <commons-lang3.version>3.12.0</commons-lang3.version>
     <slf4j.version>1.7.36</slf4j.version>
 

--- a/src/main/java/com/zeroclue/jmeter/protocol/amqp/AMQPConsumer.java
+++ b/src/main/java/com/zeroclue/jmeter/protocol/amqp/AMQPConsumer.java
@@ -5,6 +5,7 @@ import com.rabbitmq.client.ConsumerCancelledException;
 import com.rabbitmq.client.DeliverCallback;
 import com.rabbitmq.client.Delivery;
 import com.rabbitmq.client.ShutdownSignalException;
+
 import org.apache.groovy.util.Maps;
 import org.apache.jmeter.samplers.Entry;
 import org.apache.jmeter.samplers.Interruptible;
@@ -81,15 +82,15 @@ public class AMQPConsumer extends AMQPSampler implements Interruptible, TestStat
 
         try {
             initChannel();
+            response = new LinkedBlockingQueue<>(1);
             // only do this once per thread, otherwise it slows down the consumption by appx 50%
             if (consumer == null) {
                 log.info("Creating consumer");
-                response = new LinkedBlockingQueue<>(1);
                 consumer = (consumerTag, delivery) -> response.offer(delivery);
             }
             if (consumerTag == null) {
                 log.info("Starting basic consumer");
-                consumerTag = channel.basicConsume(getQueue(), autoAck(), consumer, consumerTag  -> {});
+                consumerTag = channel.basicConsume(getQueue(), autoAck(), consumer, consumerTag  -> { });
             }
         } catch (Exception ex) {
             log.error("Failed to initialize channel", ex);


### PR DESCRIPTION
Replace QueueingConsumer with DeliveryCallback, as QueueingConsumer has been removed with version 5 of amqp-client