### PR TITLE
Purge queue in `sample` rather than `testEnded`

### DIFF
--- a/src/main/java/com/zeroclue/jmeter/protocol/amqp/AMQPConsumer.java
+++ b/src/main/java/com/zeroclue/jmeter/protocol/amqp/AMQPConsumer.java
@@ -82,6 +82,9 @@ public class AMQPConsumer extends AMQPSampler implements Interruptible, TestStat
 
         try {
             initChannel();
+            if (purgeQueue()) {
+                doPurgeQueue();
+            }
             response = new LinkedBlockingQueue<>(1);
             // only do this once per thread, otherwise it slows down the consumption by appx 50%
             if (consumer == null) {
@@ -140,7 +143,6 @@ public class AMQPConsumer extends AMQPSampler implements Interruptible, TestStat
             /*
              * Set up the sample result details
              */
-
             result.setResponseMessage("OK");
             result.setDataType(SampleResult.TEXT);
             result.setResponseHeaders(delivery != null ? formatHeaders(delivery) : null);
@@ -191,6 +193,15 @@ public class AMQPConsumer extends AMQPSampler implements Interruptible, TestStat
 
     public boolean purgeQueue() {
         return Boolean.parseBoolean(getPurgeQueue());
+    }
+
+    private void doPurgeQueue() {
+        log.info("Purging queue {}", getQueue());
+        try {
+            channel.queuePurge(getQueue());
+        } catch (IOException e) {
+            log.error("Failed to purge queue " + getQueue(), e);
+        }
     }
 
     /**
@@ -287,15 +298,6 @@ public class AMQPConsumer extends AMQPSampler implements Interruptible, TestStat
     @Override
     public void testEnded() {
 
-        if (purgeQueue()) {
-            log.info("Purging queue {}", getQueue());
-
-            try {
-                channel.queuePurge(getQueue());
-            } catch (IOException e) {
-                log.error("Failed to purge queue " + getQueue(), e);
-            }
-        }
     }
 
     @Override


### PR DESCRIPTION
`testEnded` does not work as a new instance of AMQPConsumer is created
and the channel is not set (NullPointerException).
Additionally, the queue should be purged at the point of the test plan
where the consumer is and not when the test plan ended.