### PR TITLE
Fix response queue

### DIFF
--- a/src/main/java/com/zeroclue/jmeter/protocol/amqp/AMQPConsumer.java
+++ b/src/main/java/com/zeroclue/jmeter/protocol/amqp/AMQPConsumer.java
@@ -82,10 +82,10 @@ public class AMQPConsumer extends AMQPSampler implements Interruptible, TestStat
 
         try {
             initChannel();
-            response = new LinkedBlockingQueue<>(1);
             // only do this once per thread, otherwise it slows down the consumption by appx 50%
             if (consumer == null) {
                 log.info("Creating consumer");
+                response = new LinkedBlockingQueue<>(1);
                 consumer = (consumerTag, delivery) -> response.offer(delivery);
             }
             if (consumerTag == null) {


### PR DESCRIPTION
If prefetch count is e.g. `1` only the first time the consumer is encountered a message is read. The second time no message is received any more.

Bug was introduced with 927b0aee5b9e79d3afce0f22f6d0c18b3359a21c

Example that plays ping pong (test plans have .txt ending as GitHub does not allow jmx/xml files):
1. Start Pong.jmx test plan first.
  1.1. Pong.jmx publishes three Ping Messages before listening for Pong messages
2. Start Ping.jmx second
  2.1. Ping only receives the first message.
  2.2. The second message is prefetched, as the first has been acked after reading it.
  2.3. `BlockingQueue<Delivery> response` is created again in the second iteration of the loop. Therefore the second message is lost. The message is never acked and never read. The sampler is stuck.

[Ping.jmx.txt](https://github.com/aliesbelik/jmeter-amqp-plugin/files/8678697/Ping.jmx.txt)
[Pong.jmx.txt](https://github.com/aliesbelik/jmeter-amqp-plugin/files/8678698/Pong.jmx.txt)