### PR TITLE
Add app_id to AMQP publisher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+* App_id message property for AMQP Publisher (see [jlavallee#37](https://github.com/jlavallee/JMeter-Rabbit-AMQP/issues/37)).
+
 ### Dependency Updates
 
 * Up amqp-client version to 5.16.0.

--- a/docs/examples/rabbitmq-amqp-test.jmx
+++ b/docs/examples/rabbitmq-amqp-test.jmx
@@ -81,6 +81,7 @@
           <stringProp name="AMQPPublisher.ContentType">application/json</stringProp>
           <stringProp name="AMQPPublisher.ContentEncoding">utf-8</stringProp>
           <stringProp name="AMQPPublisher.MessageId"></stringProp>
+          <stringProp name="AMQPPublisher.AppId"></stringProp>
           <elementProp name="AMQPPublisher.Headers" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
             <collectionProp name="Arguments.arguments">
               <elementProp name="cc" elementType="Argument">

--- a/src/main/java/com/zeroclue/jmeter/protocol/amqp/AMQPConsumer.java
+++ b/src/main/java/com/zeroclue/jmeter/protocol/amqp/AMQPConsumer.java
@@ -48,6 +48,7 @@ public class AMQPConsumer extends AMQPSampler implements Interruptible, TestStat
     public static final String EXCHANGE_PARAMETER       = "Exchange";
     public static final String ROUTING_KEY_PARAMETER    = "Routing Key";
     public static final String DELIVERY_TAG_PARAMETER   = "Delivery Tag";
+    public static final String APP_ID_PARAMETER         = "Application ID";
 
     public static final boolean DEFAULT_PURGE_QUEUE = false;
     public static final boolean DEFAULT_AUTO_ACK = true;
@@ -380,6 +381,13 @@ public class AMQPConsumer extends AMQPSampler implements Interruptible, TestStat
             .append(": ")
             .append(delivery.getEnvelope().getDeliveryTag())
             .append("\n");
+
+        if (delivery.getProperties().getAppId() != null) {
+            sb.append(APP_ID_PARAMETER)
+                .append(": ")
+                .append(delivery.getProperties().getAppId())
+                .append("\n");
+        }
 
         if (headers != null) {
             for (Map.Entry<String,Object> entry : headers.entrySet()) {

--- a/src/main/java/com/zeroclue/jmeter/protocol/amqp/AMQPPublisher.java
+++ b/src/main/java/com/zeroclue/jmeter/protocol/amqp/AMQPPublisher.java
@@ -50,6 +50,7 @@ public class AMQPPublisher extends AMQPSampler implements Interruptible {
     private static final String HEADERS             = "AMQPPublisher.Headers";
     private static final String PERSISTENT          = "AMQPPublisher.Persistent";
     private static final String USE_TX              = "AMQPPublisher.UseTx";
+    private static final String APP_ID              = "AMQPPublisher.AppId";
 
     public static final boolean DEFAULT_PERSISTENT   = false;
     public static final boolean DEFAULT_USE_TX       = false;
@@ -264,6 +265,14 @@ public class AMQPPublisher extends AMQPSampler implements Interruptible {
         setProperty(USE_TX, tx);
     }
 
+    public String getAppId() {
+        return getPropertyAsString(APP_ID);
+    }
+
+    public void setAppId(String appId) {
+        setProperty(APP_ID, appId);
+    }
+
     @Override
     public boolean interrupt() {
         cleanup();
@@ -301,6 +310,10 @@ public class AMQPPublisher extends AMQPSampler implements Interruptible {
             builder.priority(getMessagePriorityAsInt());
         } else {
             builder.priority(DEFAULT_MESSAGE_PRIORITY);
+        }
+
+        if (getAppId() != null && !getAppId().isEmpty()) {
+            builder.appId(getAppId());
         }
 
         return builder.build();

--- a/src/main/java/com/zeroclue/jmeter/protocol/amqp/gui/AMQPPublisherGui.java
+++ b/src/main/java/com/zeroclue/jmeter/protocol/amqp/gui/AMQPPublisherGui.java
@@ -32,6 +32,7 @@ public class AMQPPublisherGui extends AMQPSamplerGui {
     private final JLabeledTextField messagePriority = new JLabeledTextField(" Message Priority");
     private final JLabeledTextField contentType = new JLabeledTextField("        Content-Type");
     private final JLabeledTextField contentEncoding = new JLabeledTextField("Content Encoding");
+    private final JLabeledTextField appId = new JLabeledTextField("       Application ID");
 
     private final JCheckBox persistent = new JCheckBox("Persistent", AMQPPublisher.DEFAULT_PERSISTENT);
     private final JCheckBox useTx = new JCheckBox("Use Transactions", AMQPPublisher.DEFAULT_USE_TX);
@@ -83,6 +84,7 @@ public class AMQPPublisherGui extends AMQPSamplerGui {
         messagePriority.setText(sampler.getMessagePriority());
         messageId.setText(sampler.getMessageId());
         message.setText(sampler.getMessage());
+        appId.setText(sampler.getAppId());
 
         configureHeaders(sampler);
     }
@@ -121,6 +123,7 @@ public class AMQPPublisherGui extends AMQPSamplerGui {
         sampler.setContentType(contentType.getText());
         sampler.setContentEncoding(contentEncoding.getText());
         sampler.setMessageId(messageId.getText());
+        sampler.setAppId(appId.getText());
 
         sampler.setHeaders((Arguments) headers.createTestElement());
     }
@@ -183,6 +186,7 @@ public class AMQPPublisherGui extends AMQPSamplerGui {
         propertyPanel.add(correlationId, constraints);
         propertyPanel.add(messageId, constraints);
         propertyPanel.add(messagePriority, constraints);
+        propertyPanel.add(appId, constraints);
         propertyPanel.add(contentType, constraints);
         propertyPanel.add(contentEncoding, constraints);
 
@@ -206,6 +210,7 @@ public class AMQPPublisherGui extends AMQPSamplerGui {
         contentEncoding.setText(AMQPPublisher.DEFAULT_ENCODING);
         messageId.setText("");
         message.setText("");
+        appId.setText("");
         headers.clearGui();
     }
 


### PR DESCRIPTION
Add missing `app_id` property for AMQP Publisher (see jlavallee#37).