### PR TITLE
feat: add timestamp to AMQP publisher (fixes jlavallee#37)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * App_id message property for AMQP Publisher (see [jlavallee#37](https://github.com/jlavallee/JMeter-Rabbit-AMQP/issues/37)).
+* Timestamp message property for AMQP Publisher (see [jlavallee#37](https://github.com/jlavallee/JMeter-Rabbit-AMQP/issues/37)).
 
 ### Dependency Updates
 

--- a/docs/examples/rabbitmq-amqp-test.jmx
+++ b/docs/examples/rabbitmq-amqp-test.jmx
@@ -1,22 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.5">
+<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.6.2">
   <hashTree>
     <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="AMQP Test Plan" enabled="true">
-      <stringProp name="TestPlan.comments"></stringProp>
       <boolProp name="TestPlan.functional_mode">false</boolProp>
       <boolProp name="TestPlan.tearDown_on_shutdown">true</boolProp>
       <boolProp name="TestPlan.serialize_threadgroups">false</boolProp>
       <elementProp name="TestPlan.user_defined_variables" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
         <collectionProp name="Arguments.arguments"/>
       </elementProp>
-      <stringProp name="TestPlan.user_define_classpath"></stringProp>
     </TestPlan>
     <hashTree>
       <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Thread Group" enabled="true">
         <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
         <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">
-          <boolProp name="LoopController.continue_forever">false</boolProp>
           <stringProp name="LoopController.loops">100</stringProp>
+          <boolProp name="LoopController.continue_forever">false</boolProp>
         </elementProp>
         <stringProp name="ThreadGroup.num_threads">10</stringProp>
         <stringProp name="ThreadGroup.ramp_time">10</stringProp>
@@ -24,6 +22,7 @@
         <stringProp name="ThreadGroup.duration"></stringProp>
         <stringProp name="ThreadGroup.delay"></stringProp>
         <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
+        <boolProp name="ThreadGroup.delayedStart">false</boolProp>
       </ThreadGroup>
       <hashTree>
         <RandomVariableConfig guiclass="TestBeanGUI" testclass="RandomVariableConfig" testname="Reply-To Queue Name" enabled="true">
@@ -82,6 +81,7 @@
           <stringProp name="AMQPPublisher.ContentEncoding">utf-8</stringProp>
           <stringProp name="AMQPPublisher.MessageId"></stringProp>
           <stringProp name="AMQPPublisher.AppId"></stringProp>
+          <boolProp name="AMQPPublisher.Timestamp">true</boolProp>
           <elementProp name="AMQPPublisher.Headers" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
             <collectionProp name="Arguments.arguments">
               <elementProp name="cc" elementType="Argument">

--- a/src/main/java/com/zeroclue/jmeter/protocol/amqp/AMQPConsumer.java
+++ b/src/main/java/com/zeroclue/jmeter/protocol/amqp/AMQPConsumer.java
@@ -365,10 +365,13 @@ public class AMQPConsumer extends AMQPSampler implements Interruptible, TestStat
         Map<String, Object> headers = delivery.getProperties().getHeaders();
         StringBuilder sb = new StringBuilder();
 
-        sb.append(TIMESTAMP_PARAMETER)
-            .append(": ")
-            .append(delivery.getProperties().getTimestamp() != null ? delivery.getProperties().getTimestamp().getTime() : "")
-            .append("\n");
+        if (delivery.getProperties().getTimestamp() != null) {
+            sb.append(TIMESTAMP_PARAMETER)
+                .append(": ")
+                .append((delivery.getProperties().getTimestamp().getTime())/1000)
+                .append("\n");
+        }
+
         sb.append(EXCHANGE_PARAMETER)
             .append(": ")
             .append(delivery.getEnvelope().getExchange())

--- a/src/main/java/com/zeroclue/jmeter/protocol/amqp/AMQPPublisher.java
+++ b/src/main/java/com/zeroclue/jmeter/protocol/amqp/AMQPPublisher.java
@@ -7,7 +7,9 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
@@ -51,9 +53,11 @@ public class AMQPPublisher extends AMQPSampler implements Interruptible {
     private static final String PERSISTENT          = "AMQPPublisher.Persistent";
     private static final String USE_TX              = "AMQPPublisher.UseTx";
     private static final String APP_ID              = "AMQPPublisher.AppId";
+    private static final String TIMESTAMP           = "AMQPPublisher.Timestamp";
 
     public static final boolean DEFAULT_PERSISTENT   = false;
     public static final boolean DEFAULT_USE_TX       = false;
+    public static final boolean DEFAULT_TIMESTAMP    = true;
     public static final int DEFAULT_MESSAGE_PRIORITY = 0;
     public static final String DEFAULT_RESPONSE_CODE = "500";
     public static final String DEFAULT_CONTENT_TYPE  = "text/plain";
@@ -273,6 +277,14 @@ public class AMQPPublisher extends AMQPSampler implements Interruptible {
         setProperty(APP_ID, appId);
     }
 
+    public boolean getTimestamp() {
+        return getPropertyAsBoolean(TIMESTAMP, DEFAULT_TIMESTAMP);
+    }
+
+    public void setTimestamp(Boolean ts) {
+        setProperty(TIMESTAMP, ts);
+    }
+
     @Override
     public boolean interrupt() {
         cleanup();
@@ -314,6 +326,10 @@ public class AMQPPublisher extends AMQPSampler implements Interruptible {
 
         if (getAppId() != null && !getAppId().isEmpty()) {
             builder.appId(getAppId());
+        }
+
+        if (getTimestamp()) {
+            builder.timestamp(Date.from(Instant.now()));
         }
 
         return builder.build();

--- a/src/main/java/com/zeroclue/jmeter/protocol/amqp/gui/AMQPPublisherGui.java
+++ b/src/main/java/com/zeroclue/jmeter/protocol/amqp/gui/AMQPPublisherGui.java
@@ -5,9 +5,11 @@ import com.zeroclue.jmeter.protocol.amqp.AMQPPublisher;
 import java.awt.Dimension;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
+
 import javax.swing.BorderFactory;
 import javax.swing.JCheckBox;
 import javax.swing.JPanel;
+import javax.swing.SwingConstants;
 
 import org.apache.jmeter.config.Arguments;
 import org.apache.jmeter.config.gui.ArgumentsPanel;
@@ -24,6 +26,7 @@ public class AMQPPublisherGui extends AMQPSamplerGui {
     private static final long serialVersionUID = 1L;
 
     private final JLabeledTextArea message = new JLabeledTextArea("Message Content");
+
     private final JLabeledTextField messageRoutingKey = new JLabeledTextField("          Routing Key");
     private final JLabeledTextField messageType = new JLabeledTextField("     Message Type");
     private final JLabeledTextField replyToQueue = new JLabeledTextField("   Reply-To Queue");
@@ -34,6 +37,7 @@ public class AMQPPublisherGui extends AMQPSamplerGui {
     private final JLabeledTextField contentEncoding = new JLabeledTextField("Content Encoding");
     private final JLabeledTextField appId = new JLabeledTextField("       Application ID");
 
+    private final JCheckBox timestamp = new JCheckBox("Timestamp", AMQPPublisher.DEFAULT_TIMESTAMP);
     private final JCheckBox persistent = new JCheckBox("Persistent", AMQPPublisher.DEFAULT_PERSISTENT);
     private final JCheckBox useTx = new JCheckBox("Use Transactions", AMQPPublisher.DEFAULT_USE_TX);
 
@@ -85,6 +89,7 @@ public class AMQPPublisherGui extends AMQPSamplerGui {
         messageId.setText(sampler.getMessageId());
         message.setText(sampler.getMessage());
         appId.setText(sampler.getAppId());
+        timestamp.setSelected(sampler.getTimestamp());
 
         configureHeaders(sampler);
     }
@@ -124,6 +129,7 @@ public class AMQPPublisherGui extends AMQPSamplerGui {
         sampler.setContentEncoding(contentEncoding.getText());
         sampler.setMessageId(messageId.getText());
         sampler.setAppId(appId.getText());
+        sampler.setTimestamp(timestamp.isSelected());
 
         sampler.setHeaders((Arguments) headers.createTestElement());
     }
@@ -180,6 +186,10 @@ public class AMQPPublisherGui extends AMQPSamplerGui {
         JPanel propertyPanel = new JPanel(new GridBagLayout());
         propertyPanel.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(), PROPS_SETTINGS_LABEL));
 
+        timestamp.setHorizontalTextPosition(SwingConstants.LEFT);
+        //timestamp.setHorizontalTextPosition(SwingConstants.LEADING);
+        timestamp.setIconTextGap(35);
+
         propertyPanel.add(messageRoutingKey, constraints);
         propertyPanel.add(replyToQueue, constraints);
         propertyPanel.add(messageType, constraints);
@@ -189,6 +199,7 @@ public class AMQPPublisherGui extends AMQPSamplerGui {
         propertyPanel.add(appId, constraints);
         propertyPanel.add(contentType, constraints);
         propertyPanel.add(contentEncoding, constraints);
+        propertyPanel.add(timestamp, constraints);
 
         return propertyPanel;
     }
@@ -199,6 +210,7 @@ public class AMQPPublisherGui extends AMQPSamplerGui {
     @Override
     public void clearGui() {
         super.clearGui();
+
         persistent.setSelected(AMQPPublisher.DEFAULT_PERSISTENT);
         useTx.setSelected(AMQPPublisher.DEFAULT_USE_TX);
         messageRoutingKey.setText("");
@@ -211,6 +223,8 @@ public class AMQPPublisherGui extends AMQPSamplerGui {
         messageId.setText("");
         message.setText("");
         appId.setText("");
+        timestamp.setSelected(AMQPPublisher.DEFAULT_TIMESTAMP);
+
         headers.clearGui();
     }
 


### PR DESCRIPTION
Add missing [timestamp](https://www.rabbitmq.com/amqp-0-9-1-reference.html#domain.timestamp) property for AMQP Publisher (see jlavallee#37).